### PR TITLE
change server ip to 0.0.0.0 

### DIFF
--- a/happytime-rtsp-server/config.xml
+++ b/happytime-rtsp-server/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
-	<serverip>127.0.0.1</serverip>
+	<serverip>0.0.0.0</serverip>
 	<serverport>6554</serverport>
 	<loop_nums>-1</loop_nums>
 	<multicast>1</multicast>	


### PR DESCRIPTION
change server ip to 0.0.0.0 so that rtsp server is reachable from docker containers in cluster tests and also reachable on standalone tests. with 127.0.0.1 docker containers on cluster tests cannot reach rtsp server